### PR TITLE
Scry and basic version of drop zones

### DIFF
--- a/card.js
+++ b/card.js
@@ -1,24 +1,24 @@
 export default class Card extends Phaser.GameObjects.Sprite{
     pointerover = false;
     tapped = false;
+    scrying = false;
     constructor(scene, x, y, sprite){
         super(scene, x, y, sprite);
-
         scene.add.existing(this)
         this.setInteractive();
         this.card_augmented = scene.add.sprite(1300, 350, sprite);
-        
+        this.card_augmented.setFrame(0);
         this.card_augmented.setAlpha(0)
         this.setScale(0.2);
         scene.input.setDraggable(this);
 
         this.on('pointerover', function () {
-
             this.card_augmented.setAlpha(1);
             this.pointerover = true;
         });
         
         this.on('pointerout', function () {
+            this.card_augmented.setFrame(Number(this.frame.name)); // Se o rato sair do scry antes de lagar o "S", a vista volta ao normal
             this.card_augmented.setAlpha(0);
             this.pointerover = false;
         });
@@ -37,7 +37,6 @@ export default class Card extends Phaser.GameObjects.Sprite{
             this.rotation -= 3.14/2;
             this.tapped = false;
         }
-        
     }
 
     flip(){
@@ -48,6 +47,21 @@ export default class Card extends Phaser.GameObjects.Sprite{
         else{
             this.setFrame(0);
             this.card_augmented.setFrame(0);
+        }
+    }
+
+    scry(){
+        if(this.scrying == false){
+            if(this.frame.name == 1){
+                this.card_augmented.setFrame(0);
+            }
+            else{
+                this.card_augmented.setFrame(1);
+            }
+            this.scrying = true;
+        }
+        else{
+            this.card_augmented.setFrame(Number(!this.card_augmented.frame.name));
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -38,8 +38,13 @@ function create ()
 
     dice = new Dice(this,200,200, 'dice')
 
-    keys = this.input.keyboard.addKeys('T,F,R');
+    keys = this.input.keyboard.addKeys('T,F,R,S');
     numbers = this.input.keyboard.addKeys('ONE,TWO,THREE,FOUR,FIVE,SIX');
+
+    var deckZone = this.add.zone(988, 398).setRectangleDropZone(114, 160);
+    var pitchZone = this.add.zone(860, 398).setRectangleDropZone(114, 160);
+    var graveZone = this.add.zone(988, 228).setRectangleDropZone(114, 160);
+    var banishedZone = this.add.zone(988, 570).setRectangleDropZone(114, 160);
 
     this.input.on('drag', function (pointer, gameObject, dragX, dragY) {
 
@@ -48,7 +53,12 @@ function create ()
 
     });
 
-            
+    this.input.on('drop', function (pointer, gameObject, dropZone) {
+
+        gameObject.x = dropZone.x;
+        gameObject.y = dropZone.y;
+    
+    });
 }
 
 function update ()
@@ -64,6 +74,13 @@ function update ()
         var card = overedCard(cards_on_board);
         if (card != false){
             card.flip();
+        }
+    }
+
+    if(Phaser.Input.Keyboard.JustDown(keys.S) || Phaser.Input.Keyboard.JustUp(keys.S)){
+        var card = overedCard(cards_on_board);
+        if (card != false){
+            card.scry();
         }
     }
 


### PR DESCRIPTION
Scry funciona, mas se o rato sair de cima da carta enquanto o "S" está primido, a flag "scrying" passa-se. 
Drop zones para grave, banished, pitch e deck.